### PR TITLE
feat: Add CometAPI as provider support with model selection and API integration

### DIFF
--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -2444,7 +2444,7 @@ export function getStreamingReply(data, state, { chatCompletionSource = null, ov
                 '';
         }
         return data.choices?.[0]?.delta?.content ?? data.choices?.[0]?.message?.content ?? data.choices?.[0]?.text ?? '';
-    } else if (chat_completion_source === chat_completion_sources.COMETAPI) {
+    } else {
         return data.choices?.[0]?.delta?.content ?? data.choices?.[0]?.message?.content ?? data.choices?.[0]?.text ?? '';
     }
 }
@@ -3342,7 +3342,7 @@ export class ChatCompletion {
     }
 }
 
-async function loadOpenAISettings(data, settings) {
+function loadOpenAISettings(data, settings) {
     openai_setting_names = data.openai_setting_names;
     openai_settings = data.openai_settings;
     openai_settings.forEach(function (item, i, arr) {
@@ -3412,25 +3412,18 @@ async function loadOpenAISettings(data, settings) {
     oai_settings.proxy_password = settings.proxy_password ?? default_settings.proxy_password;
     oai_settings.assistant_prefill = settings.assistant_prefill ?? default_settings.assistant_prefill;
     oai_settings.assistant_impersonation = settings.assistant_impersonation ?? default_settings.assistant_impersonation;
-    oai_settings.claude_use_sysprompt = settings.claude_use_sysprompt ?? default_settings.claude_use_sysprompt;
-    oai_settings.use_makersuite_sysprompt = settings.use_makersuite_sysprompt ?? default_settings.use_makersuite_sysprompt;
-    oai_settings.vertexai_auth_mode = settings.vertexai_auth_mode ?? default_settings.vertexai_auth_mode;
-    oai_settings.vertexai_region = settings.vertexai_region ?? default_settings.vertexai_region;
-    oai_settings.vertexai_express_project_id = settings.vertexai_express_project_id ?? default_settings.vertexai_express_project_id;
-    oai_settings.squash_system_messages = settings.squash_system_messages ?? default_settings.squash_system_messages;
     oai_settings.image_inlining = settings.image_inlining ?? default_settings.image_inlining;
     oai_settings.inline_image_quality = settings.inline_image_quality ?? default_settings.inline_image_quality;
     oai_settings.video_inlining = settings.video_inlining ?? default_settings.video_inlining;
     oai_settings.bypass_status_check = settings.bypass_status_check ?? default_settings.bypass_status_check;
-    oai_settings.continue_prefill = settings.continue_prefill ?? default_settings.continue_prefill;
-    oai_settings.continue_postfix = settings.continue_postfix ?? default_settings.continue_postfix;
-    oai_settings.function_calling = settings.function_calling ?? default_settings.function_calling;
+    oai_settings.vertexai_express_project_id = settings.vertexai_express_project_id ?? default_settings.vertexai_express_project_id;
     oai_settings.show_thoughts = settings.show_thoughts ?? default_settings.show_thoughts;
     oai_settings.reasoning_effort = settings.reasoning_effort ?? default_settings.reasoning_effort;
     oai_settings.enable_web_search = settings.enable_web_search ?? default_settings.enable_web_search;
     oai_settings.request_images = settings.request_images ?? default_settings.request_images;
     oai_settings.seed = settings.seed ?? default_settings.seed;
     oai_settings.n = settings.n ?? default_settings.n;
+
     oai_settings.prompts = settings.prompts ?? default_settings.prompts;
     oai_settings.prompt_order = settings.prompt_order ?? default_settings.prompt_order;
 
@@ -4666,7 +4659,7 @@ async function onModelChange() {
                 $('#openai_max_context').attr('max', max_8k);
             }
         }
-        oai_settings.openai_max_context = Math.min(oai_settings.openai_max_context, Number($('#openai_max_context').attr('max')));
+        oai_settings.openai_max_context = Math.min(Number($('#openai_max_context').attr('max')), oai_settings.openai_max_context);
         $('#openai_max_context').val(oai_settings.openai_max_context).trigger('input');
 
         if (value && (value.includes('claude') || value.includes('palm-2'))) {
@@ -4718,7 +4711,7 @@ async function onModelChange() {
     if (oai_settings.chat_completion_source === chat_completion_sources.MISTRALAI) {
         const maxContext = getMistralMaxContext(oai_settings.mistralai_model, oai_settings.max_context_unlocked);
         $('#openai_max_context').attr('max', maxContext);
-        oai_settings.openai_max_context = Math.min(Number($('#openai_max_context').attr('max')), oai_settings.openai_max_context);
+        oai_settings.openai_max_context = Math.min(oai_settings.openai_max_context, Number($('#openai_max_context').attr('max')));
         $('#openai_max_context').val(oai_settings.openai_max_context).trigger('input');
         oai_settings.temp_openai = Math.min(claude_max_temp, oai_settings.temp_openai);
         $('#temp_openai').attr('max', claude_max_temp).val(oai_settings.temp_openai).trigger('input');
@@ -4775,7 +4768,7 @@ async function onModelChange() {
         $('#temp_openai').attr('max', oai_max_temp).val(oai_settings.temp_openai).trigger('input');
     }
 
-    if (oai_settings.chat_completion_source === chat_completion_sources.GROQ) {
+    if (oai_settings.chat_completion_source == chat_completion_sources.GROQ) {
         const maxContext = getGroqMaxContext(oai_settings.groq_model, oai_settings.max_context_unlocked);
         $('#openai_max_context').attr('max', maxContext);
         oai_settings.openai_max_context = Math.min(Number($('#openai_max_context').attr('max')), oai_settings.openai_max_context);
@@ -4784,7 +4777,7 @@ async function onModelChange() {
         $('#temp_openai').attr('max', oai_max_temp).val(oai_settings.temp_openai).trigger('input');
     }
 
-    if (oai_settings.chat_completion_source === chat_completion_sources.AI21) {
+    if (oai_settings.chat_completion_source == chat_completion_sources.AI21) {
         if (oai_settings.max_context_unlocked) {
             $('#openai_max_context').attr('max', unlocked_max);
         } else if (oai_settings.ai21_model.startsWith('jamba-')) {
@@ -4796,7 +4789,7 @@ async function onModelChange() {
         $('#temp_openai').attr('max', oai_max_temp).val(oai_settings.temp_openai).trigger('input');
     }
 
-    if (oai_settings.chat_completion_source === chat_completion_sources.CUSTOM) {
+    if (oai_settings.chat_completion_source == chat_completion_sources.CUSTOM) {
         $('#openai_max_context').attr('max', unlocked_max);
         oai_settings.openai_max_context = Math.min(Number($('#openai_max_context').attr('max')), oai_settings.openai_max_context);
         $('#openai_max_context').val(oai_settings.openai_max_context).trigger('input');
@@ -5362,7 +5355,8 @@ async function onCustomizeParametersClick() {
 
     template.find('#custom_include_headers').val(oai_settings.custom_include_headers).on('input', function () {
         oai_settings.custom_include_headers = String($(this).val());
-        saveSettingsDebounced();});
+        saveSettingsDebounced();
+    });
 
     await callGenericPopup(template, POPUP_TYPE.TEXT, '', { wide: true, large: true });
 }

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -5182,25 +5182,56 @@ async function onConnectButtonClick(e) {
 
             // Immediately refresh the model list before saving to secret_state (which will clear the input box).
             try {
-                const response = await fetch('/api/cometapi/models', {
+                const originalResponse = await fetch(apiUrl + '/models', {
                     method: 'GET',
-                    headers: Object.assign({}, getRequestHeaders(), {
-                        'Authorization': `Bearer ${api_key_cometapi}`,
-                    }),
+                    headers: {
+                        'Authorization': 'Bearer ' + apiKey,
+                        'Accept': 'application/json',
+                    },
                 });
 
-                if (response.ok) {
-                    const models = await response.json();
-                    console.log('DEBUG: Connect button - Successfully loaded', models.length, 'models');
-                    if (Array.isArray(models) && models.length > 0) {
-                        model_list = models;
-                        saveModelList(models);
-                    }
-                } else {
-                    console.warn('DEBUG: Connect button - Models request failed:', response.status);
+                if (!originalResponse.ok) {
+                    throw new Error(`HTTP ${originalResponse.status}`);
                 }
+
+                /** @type {any} */
+                const originalData = await originalResponse.json();
+                const models = originalData?.data || originalData?.models || originalData || [];
+                // Apply the same filtering logic as in cometapi.js
+                const filteredModels = models.filter(model => {
+                    const modelId = model.id.toLowerCase();
+
+                    // Filter out image generation models
+                    const imageGenPatterns = [
+                        'dall-e', 'dalle', 'midjourney', 'mj_', 'stable-diffusion', 'sd-',
+                        'flux-', 'playground-v', 'ideogram', 'recraft-', 'black-forest-labs',
+                        '/recraft-v3', 'recraftv3', 'stability-ai/', 'sdxl',
+                    ];
+
+                    // Filter out video generation models
+                    const videoGenPatterns = [
+                        'runway', 'luma_', 'luma-', 'veo', 'kling_', 'minimax_video', 'hunyuan-t1',
+                    ];
+
+                    // Filter out audio/music generation models
+                    const audioGenPatterns = ['suno_', 'tts', 'whisper'];
+
+                    // Filter out utility models
+                    const utilityPatterns = ['embedding', 'search-gpts', 'files_retrieve', 'moderation'];
+
+                    const isImageModel = imageGenPatterns.some(pattern => modelId.includes(pattern));
+                    const isVideoModel = videoGenPatterns.some(pattern => modelId.includes(pattern));
+                    const isAudioModel = audioGenPatterns.some(pattern => modelId.includes(pattern));
+                    const isUtilityModel = utilityPatterns.some(pattern => modelId.includes(pattern));
+
+                    return !isImageModel && !isVideoModel && !isAudioModel && !isUtilityModel;
+                });
+
+                statusResponse.send({ data: filteredModels });
+                return;
             } catch (error) {
-                console.warn('DEBUG: Connect button - Error fetching models:', error);
+                console.error('CometAPI filtering error:', error);
+                // Fallback to original behavior
             }
 
             // Save to secret state like other APIs
@@ -5281,10 +5312,6 @@ function toggleChatCompletionForms() {
     }
     else if (oai_settings.chat_completion_source == chat_completion_sources.COMETAPI) {
         $('#cometapi_model').trigger('change');
-        // Auto-refresh models if API key is available
-        if (secret_state[SECRET_KEYS.COMETAPI]) {
-            refreshCometAPIModels();
-        }
     }
     $('[data-source]').each(function () {
         const validSources = $(this).data('source').split(',');
@@ -6276,11 +6303,8 @@ async function initCometAPI() {
         main_api === 'openai') {
         // console.log('DEBUG: CometAPI has secret_state credentials and is selected, triggering auto-connect...');
         setTimeout(() => {
-            // console.log('DEBUG: Executing reconnectOpenAi for CometAPI...');
             reconnectOpenAi();
         }, 500);
-    } else {
-        // console.log('DEBUG: CometAPI auto-connect conditions NOT met');
     }
 }async function refreshCometAPIModels() {
     console.log('DEBUG: refreshCometAPIModels called');

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -88,7 +88,6 @@ export {
     IdentifierNotFoundError,
     Message,
     MessageCollection,
-    initCometAPI,
     getCometAPIModelName,
     isCometAPIConfigured,
 };
@@ -3617,9 +3616,6 @@ async function loadOpenAISettings(data, settings) {
     $('#oai_max_context_unlocked').prop('checked', oai_settings.max_context_unlocked);
     $('#custom_prompt_post_processing').val(oai_settings.custom_prompt_post_processing);
     $(`#custom_prompt_post_processing option[value="${oai_settings.custom_prompt_post_processing}"]`).prop('selected', true);
-
-    // Initialize CometAPI
-    initCometAPI();
 }
 
 function setNamesBehaviorControls() {
@@ -6261,11 +6257,6 @@ export function initOpenAI() {
     $('#openai_proxy_preset').on('change', onProxyPresetChange);
 
 
-    // CometAPI event bindings
-    $('#cometapi_refresh_models').on('click', function() {
-        console.log('DEBUG: Manual CometAPI refresh button clicked');
-        refreshCometAPIModels();
-    });
 
     // CometAPI is automatically connected when page initialization (as long as there is a key and the current source is cometapi)
     setTimeout(() => {
@@ -6281,93 +6272,6 @@ export function initOpenAI() {
     }, 500);
 }
 
-
-async function initCometAPI() {
-    // console.log('DEBUG: initCometAPI called');
-
-    // Only bind event handlers, no special settings
-    $('#cometapi_api_key').on('input', function() {
-        // Just store in secret_state like other APIs, no special cometapi_settings
-        // console.log('DEBUG: CometAPI API key input changed');
-    });
-
-    $('#cometapi_model').on('change', function() {
-        oai_settings.cometapi_model = String($(this).val() || '');
-        saveSettingsDebounced();
-        // console.log('DEBUG: CometAPI model changed to:', oai_settings.cometapi_model);
-    });
-
-    // Auto-connect logic like other APIs
-    if (secret_state[SECRET_KEYS.COMETAPI] &&
-        oai_settings.chat_completion_source === chat_completion_sources.COMETAPI &&
-        main_api === 'openai') {
-        // console.log('DEBUG: CometAPI has secret_state credentials and is selected, triggering auto-connect...');
-        setTimeout(() => {
-            reconnectOpenAi();
-        }, 500);
-    }
-}async function refreshCometAPIModels() {
-    console.log('DEBUG: refreshCometAPIModels called');
-
-    // METHOD: Imitate the logic of the Connect button to obtain the complete API key.
-    let apiKey = '';
-
-    // Step 1: Try to get from input field (like Connect button does)
-    apiKey = String($('#cometapi_api_key').val()).trim();
-    // console.log('DEBUG: Method 1 - API key from input field, length:', apiKey.length);
-
-
-    if (!apiKey) {
-        // toastr.error('Please enter your CometAPI key first');
-        // console.error('DEBUG: No CometAPI API key provided, aborting refresh.');
-        return;
-    }
-
-    const refreshButton = $('#cometapi_refresh_models');
-    const originalHtml = refreshButton.html();
-
-    try {
-        // Show loading state
-        refreshButton.html('<i class="fa-solid fa-spinner fa-spin"></i> Loading...');
-        refreshButton.prop('disabled', true);
-
-        console.log('DEBUG: Making CometAPI models request with API key length:', apiKey.length);
-
-        const response = await fetch('/api/cometapi/models', {
-            method: 'GET',
-            headers: Object.assign({}, getRequestHeaders(), {
-                'Authorization': `Bearer ${apiKey}`,
-            }),
-        });
-
-        console.log('DEBUG: CometAPI models response status:', response.status);
-
-        if (!response.ok) {
-            const errorText = await response.text();
-            console.error('DEBUG: CometAPI models request failed:', response.status, errorText);
-            throw new Error(`HTTP ${response.status}: ${response.statusText}`);
-        }
-
-        const models = await response.json();
-        console.log('DEBUG: CometAPI models received:', models.length, 'models');
-
-        if (Array.isArray(models) && models.length > 0) {
-            model_list = models;
-            saveModelList(models);
-        } else {
-            model_list = [];
-            // console.log('DEBUG: Empty or invalid models response');
-            toastr.warning('No CometAPI models available. All models may have been filtered out.');
-        }
-    } catch (error) {
-        console.error('DEBUG: Error fetching CometAPI models:', error);
-        toastr.error(`Failed to fetch models: ${error.message}`);
-    } finally {
-        // Restore button state
-        refreshButton.html(originalHtml);
-        refreshButton.prop('disabled', false);
-    }
-}
 
 function getCometAPIModelName() {
     return oai_settings.cometapi_model || 'No model selected';

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -1276,74 +1276,16 @@ router.post('/status', async function (request, statusResponse) {
     }
 
     try {
-        let response;
+        const response = await fetch(apiUrl + '/models', {
+            method: 'GET',
+            headers: {
+                'Authorization': 'Bearer ' + apiKey,
+                ...headers,
+            },
+        });
 
-        // For CometAPI, use our filtered endpoint internally
-        if (request.body.chat_completion_source === CHAT_COMPLETION_SOURCES.COMETAPI) {
-            // Use the filtering logic directly
-            try {
-                const originalResponse = await fetch(apiUrl + '/models', {
-                    method: 'GET',
-                    headers: {
-                        'Authorization': 'Bearer ' + apiKey,
-                        'Accept': 'application/json',
-                    },
-                });
+        if (response.ok) {
 
-                if (!originalResponse.ok) {
-                    throw new Error(`HTTP ${originalResponse.status}`);
-                }
-
-                /** @type {any} */
-                const originalData = await originalResponse.json();
-                const models = originalData?.data || originalData?.models || originalData || [];
-                // Apply the same filtering logic as in cometapi.js
-                const filteredModels = models.filter(model => {
-                    const modelId = model.id.toLowerCase();
-
-                    // Filter out image generation models
-                    const imageGenPatterns = [
-                        'dall-e', 'dalle', 'midjourney', 'mj_', 'stable-diffusion', 'sd-',
-                        'flux-', 'playground-v', 'ideogram', 'recraft-', 'black-forest-labs',
-                        '/recraft-v3', 'recraftv3', 'stability-ai/', 'sdxl',
-                    ];
-
-                    // Filter out video generation models
-                    const videoGenPatterns = [
-                        'runway', 'luma_', 'luma-', 'veo', 'kling_', 'minimax_video', 'hunyuan-t1',
-                    ];
-
-                    // Filter out audio/music generation models
-                    const audioGenPatterns = ['suno_', 'tts', 'whisper'];
-
-                    // Filter out utility models
-                    const utilityPatterns = ['embedding', 'search-gpts', 'files_retrieve', 'moderation'];
-
-                    const isImageModel = imageGenPatterns.some(pattern => modelId.includes(pattern));
-                    const isVideoModel = videoGenPatterns.some(pattern => modelId.includes(pattern));
-                    const isAudioModel = audioGenPatterns.some(pattern => modelId.includes(pattern));
-                    const isUtilityModel = utilityPatterns.some(pattern => modelId.includes(pattern));
-
-                    return !isImageModel && !isVideoModel && !isAudioModel && !isUtilityModel;
-                });
-
-                statusResponse.send({ data: filteredModels });
-                return;
-            } catch (error) {
-                console.error('CometAPI filtering error:', error);
-                // Fallback to original behavior
-            }
-        } else {
-            response = await fetch(apiUrl + '/models', {
-                method: 'GET',
-                headers: {
-                    'Authorization': 'Bearer ' + apiKey,
-                    ...headers,
-                },
-            });
-        }
-
-        if (response && response.ok) {
             /** @type {any} */
             let data = await response.json();
 

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -1276,16 +1276,74 @@ router.post('/status', async function (request, statusResponse) {
     }
 
     try {
-        const response = await fetch(apiUrl + '/models', {
-            method: 'GET',
-            headers: {
-                'Authorization': 'Bearer ' + apiKey,
-                ...headers,
-            },
-        });
+        let response;
 
-        if (response.ok) {
+        // For CometAPI, use our filtered endpoint internally
+        if (request.body.chat_completion_source === CHAT_COMPLETION_SOURCES.COMETAPI) {
+            // Use the filtering logic directly
+            try {
+                const originalResponse = await fetch(apiUrl + '/models', {
+                    method: 'GET',
+                    headers: {
+                        'Authorization': 'Bearer ' + apiKey,
+                        'Accept': 'application/json',
+                    },
+                });
 
+                if (!originalResponse.ok) {
+                    throw new Error(`HTTP ${originalResponse.status}`);
+                }
+
+                /** @type {any} */
+                const originalData = await originalResponse.json();
+                const models = originalData?.data || originalData?.models || originalData || [];
+                // Apply the same filtering logic as in cometapi.js
+                const filteredModels = models.filter(model => {
+                    const modelId = model.id.toLowerCase();
+
+                    // Filter out image generation models
+                    const imageGenPatterns = [
+                        'dall-e', 'dalle', 'midjourney', 'mj_', 'stable-diffusion', 'sd-',
+                        'flux-', 'playground-v', 'ideogram', 'recraft-', 'black-forest-labs',
+                        '/recraft-v3', 'recraftv3', 'stability-ai/', 'sdxl',
+                    ];
+
+                    // Filter out video generation models
+                    const videoGenPatterns = [
+                        'runway', 'luma_', 'luma-', 'veo', 'kling_', 'minimax_video', 'hunyuan-t1',
+                    ];
+
+                    // Filter out audio/music generation models
+                    const audioGenPatterns = ['suno_', 'tts', 'whisper'];
+
+                    // Filter out utility models
+                    const utilityPatterns = ['embedding', 'search-gpts', 'files_retrieve', 'moderation'];
+
+                    const isImageModel = imageGenPatterns.some(pattern => modelId.includes(pattern));
+                    const isVideoModel = videoGenPatterns.some(pattern => modelId.includes(pattern));
+                    const isAudioModel = audioGenPatterns.some(pattern => modelId.includes(pattern));
+                    const isUtilityModel = utilityPatterns.some(pattern => modelId.includes(pattern));
+
+                    return !isImageModel && !isVideoModel && !isAudioModel && !isUtilityModel;
+                });
+
+                statusResponse.send({ data: filteredModels });
+                return;
+            } catch (error) {
+                console.error('CometAPI filtering error:', error);
+                // Fallback to original behavior
+            }
+        } else {
+            response = await fetch(apiUrl + '/models', {
+                method: 'GET',
+                headers: {
+                    'Authorization': 'Bearer ' + apiKey,
+                    ...headers,
+                },
+            });
+        }
+
+        if (response && response.ok) {
             /** @type {any} */
             let data = await response.json();
 


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).

## Summary

This PR adds support for [CometAPI](https://cometapi.com), a unified AI API gateway that provides access to multiple language models through a single interface.

<img width="850" height="576" alt="image" src="https://github.com/user-attachments/assets/33dc1064-5eec-4ce6-a390-4c4cbd3b2112" />


## What is CometAPI?

CometAPI is an API aggregation service that offers:
- Access to various AI models (Claude, GPT, Gemini, etc.) through a unified OpenAI-compatible API
- Simplified API key management - one key for multiple providers
- Consistent pricing and billing across different models
- High availability and reliability

## Changes Made

### Backend
- **Added CometAPI endpoint** (`src/endpoints/cometapi.js`): 
  - Implements model filtering to exclude non-chat models (image generation, video, audio, TTS, embedding models)
  - Provides a clean list of chat-only models for better user experience
  
- **Integrated CometAPI in chat completions** (`src/endpoints/backends/chat-completions.js`):
  - Added CometAPI as a new chat completion source
  - Implemented proper request routing and authentication

### Frontend
- **Added CometAPI UI components** (`public/index.html`):
  - New CometAPI settings panel with API key input and model selector
  - Consistent UI design matching other API providers
  
- **Implemented CometAPI client logic** (`public/scripts/openai.js`):
  - Model list fetching and caching
  - Automatic connection on page refresh when API key is present
  - Settings persistence using localStorage
  - Proper error handling and user feedback

- **Added CometAPI constants** (`src/constants.js`):
  - Added CometAPI to `CHAT_COMPLETION_SOURCES` enum
  - Defined CometAPI secret key for secure storage



